### PR TITLE
Add config options to python client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 1.0.2 August 11, 2016
   - Initial Release
+1.1.0 September 28, 2016
+  - Added config options: hostname, port, secure, timeout
+   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-1.0.2 August 11, 2016
-  - Initial Release
 1.1.0 September 28, 2016
   - Added config options: hostname, port, secure, timeout
+1.0.2 August 11, 2016
+  - Initial Release
    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-1.1.0 September 28, 2016
+1.1.0 October 4, 2016
   - Added config options: hostname, port, secure, timeout
 1.0.2 August 11, 2016
   - Initial Release
-   

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ You may optionally supply a config argument with your API key:
     'hostname': 'api.testsite.com',
     'port': 80,
     'secure': False,
-    'timeout': 5 # seconds
+    'timeout': 5, # seconds
   })
 
 The supported options are as follows:

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,27 @@ instance:
     print(response.to_dict())
     # {'status': open, 'btn_ref': None, 'line_items': [], ...}
 
+Configuration
+---------
+
+You may optionally supply a config argument with your API key:
+
+.. code:: python
+
+  client = Client("sk-XXX", {
+    'hostname': 'api.testsite.com',
+    'port': 80,
+    'secure': False,
+    'timeout': 5
+  })
+
+The supported options are as follows:
+
+* ``hostname``: Defaults to ``api.usebutton.com``.
+* ``port``: Defaults to ``443`` if ``config.secure``, else defaults to ``80``.
+* ``secure``: Whether or not to use HTTPS.  Defaults to ``True``.  **N.B: Button's API is only exposed through HTTPS.  This option is provided purely as a convenience for testing and development.**
+* ``timeout``: The time in seconds that may elapse before network requests abort.  Defaults to ``None``.
+
 Resources
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -66,17 +66,19 @@ instance:
     # {'status': open, 'btn_ref': None, 'line_items': [], ...}
 
 Configuration
----------
+-------------
 
 You may optionally supply a config argument with your API key:
 
 .. code:: python
 
+  from pybutton import Client
+
   client = Client("sk-XXX", {
     'hostname': 'api.testsite.com',
     'port': 80,
     'secure': False,
-    'timeout': 5
+    'timeout': 5 # seconds
   })
 
 The supported options are as follows:

--- a/pybutton/client.py
+++ b/pybutton/client.py
@@ -17,6 +17,13 @@ class Client(object):
         api_key (string): Your organization's API key.  Do find yours at
             https://app.usebutton.com/settings/organization.
 
+        config (dict): Configuration options for the client. Options include:
+            timeout: The time in ms for network requests to abort. Defaults to None.
+            hostname: Defaults to api.usebutton.com.
+            port: Defaults to 443 if config.secure, else defaults to 80.
+            secure: Whether or not to use HTTPS. Defaults to True.
+              (N.B: Button's API is only exposed through HTTPS. This option is provided purely as a convenience for testing and development.)
+
     Attributes:
         orders (pybutton.Resource): Resource for managing Button Orders.
 
@@ -25,7 +32,7 @@ class Client(object):
 
     '''
 
-    def __init__(self, api_key):
+    def __init__(self, api_key, config={}):
 
         if not api_key:
             raise ButtonClientError((
@@ -33,4 +40,17 @@ class Client(object):
                 ' https://app.usebutton.com/settings/organization'
             ))
 
-        self.orders = Orders(api_key)
+        config = self._config_with_defaults(config)
+
+        self.orders = Orders(api_key, config)
+
+    def _config_with_defaults(self, config):
+        secure = config.get('secure', True)
+        defaultPort = 443 if secure else 80
+
+        return {
+            'secure': secure,
+            'timeout': config.get('timeout'),
+            'hostname': config.get('hostname', 'api.usebutton.com'),
+            'port': config.get('port', defaultPort)
+        }

--- a/pybutton/client.py
+++ b/pybutton/client.py
@@ -18,10 +18,10 @@ class Client(object):
             https://app.usebutton.com/settings/organization.
 
         config (dict): Configuration options for the client. Options include:
-            timeout: The time in ms for network requests to abort. Defaults to None.
             hostname: Defaults to api.usebutton.com.
             port: Defaults to 443 if config.secure, else defaults to 80.
             secure: Whether or not to use HTTPS. Defaults to True.
+            timeout: The time in seconds for network requests to abort. Defaults to None.
               (N.B: Button's API is only exposed through HTTPS. This option is provided purely as a convenience for testing and development.)
 
     Attributes:
@@ -32,7 +32,7 @@ class Client(object):
 
     '''
 
-    def __init__(self, api_key, config={}):
+    def __init__(self, api_key, config=None):
 
         if not api_key:
             raise ButtonClientError((
@@ -40,17 +40,21 @@ class Client(object):
                 ' https://app.usebutton.com/settings/organization'
             ))
 
-        config = self._config_with_defaults(config)
+        if config is None:
+            config = {}
+
+        config = _config_with_defaults(config)
 
         self.orders = Orders(api_key, config)
 
-    def _config_with_defaults(self, config):
-        secure = config.get('secure', True)
-        defaultPort = 443 if secure else 80
 
-        return {
-            'secure': secure,
-            'timeout': config.get('timeout'),
-            'hostname': config.get('hostname', 'api.usebutton.com'),
-            'port': config.get('port', defaultPort)
-        }
+def _config_with_defaults(config):
+    secure = config.get('secure', True)
+    defaultPort = 443 if secure else 80
+
+    return {
+        'secure': secure,
+        'timeout': config.get('timeout'),
+        'hostname': config.get('hostname', 'api.usebutton.com'),
+        'port': config.get('port', defaultPort)
+    }

--- a/pybutton/client.py
+++ b/pybutton/client.py
@@ -21,8 +21,10 @@ class Client(object):
             hostname: Defaults to api.usebutton.com.
             port: Defaults to 443 if config.secure, else defaults to 80.
             secure: Whether or not to use HTTPS. Defaults to True.
-            timeout: The time in seconds for network requests to abort. Defaults to None.
-              (N.B: Button's API is only exposed through HTTPS. This option is provided purely as a convenience for testing and development.)
+            timeout: The time in seconds for network requests to abort.
+              Defaults to None.
+              (N.B: Button's API is only exposed through HTTPS. This option is
+              provided purely as a convenience for testing and development.)
 
     Attributes:
         orders (pybutton.Resource): Resource for managing Button Orders.
@@ -43,12 +45,12 @@ class Client(object):
         if config is None:
             config = {}
 
-        config = _config_with_defaults(config)
+        config = config_with_defaults(config)
 
         self.orders = Orders(api_key, config)
 
 
-def _config_with_defaults(config):
+def config_with_defaults(config):
     secure = config.get('secure', True)
     defaultPort = 443 if secure else 80
 

--- a/pybutton/client.py
+++ b/pybutton/client.py
@@ -58,5 +58,5 @@ def config_with_defaults(config):
         'secure': secure,
         'timeout': config.get('timeout'),
         'hostname': config.get('hostname', 'api.usebutton.com'),
-        'port': config.get('port', defaultPort)
+        'port': config.get('port', defaultPort),
     }

--- a/pybutton/request.py
+++ b/pybutton/request.py
@@ -59,7 +59,9 @@ if sys.version_info[0] == 3:
             raise ButtonClientError('Invalid response: {0}'.format(response))
 
     def request_url(secure, hostname, port, path):
-        '''Combines url components into a url passable into the request function.'''
+        ''' Combines url components into a url passable into the request
+        function. '''
+
         scheme = 'https' if secure else 'http'
         netloc = '{0}:{1}'.format(hostname, port)
 
@@ -113,7 +115,8 @@ else:
             raise ButtonClientError('Invalid response: {0}'.format(response))
 
     def request_url(secure, hostname, port, path):
-        '''Combines url components into a url passable into the request function.'''
+        ''' Combines url components into a url passable into the request
+        function. '''
         scheme = 'https' if secure else 'http'
         netloc = '{0}:{1}'.format(hostname, port)
 

--- a/pybutton/request.py
+++ b/pybutton/request.py
@@ -105,8 +105,18 @@ else:
 
 
 def request_url(secure, hostname, port, path):
-    ''' Combines url components into a url passable into the request
-    function. '''
+    '''
+        Combines url components into a url passable into the request function.
+
+        Args:
+            secure (boolean): Whether or not to use HTTPS.
+            hostname (str): The host name for the url.
+            port (int): The port number, as an integer.
+            path (str): The hierarchical path.
+
+        Returns:
+            (str) A complete url made up of the arguments.
+    '''
     scheme = 'https' if secure else 'http'
     netloc = '{0}:{1}'.format(hostname, port)
 

--- a/pybutton/request.py
+++ b/pybutton/request.py
@@ -21,7 +21,7 @@ if sys.version_info[0] == 3:
     from urllib.request import urlopen
     from urllib.error import HTTPError
 
-    def request(url, method, headers, data=None):
+    def request(url, method, headers, data=None, timeout=None):
         ''' Make an HTTP request in Python 3.x
 
         This method will abstract the underlying organization and invocation of
@@ -50,7 +50,7 @@ if sys.version_info[0] == 3:
         if data:
             request.add_header('Content-Type', 'application/json')
 
-        response = urlopen(request).read().decode('utf8')
+        response = urlopen(request, timeout=timeout).read().decode('utf8')
 
         try:
             return json.loads(response)
@@ -64,7 +64,7 @@ else:
     from urllib2 import urlopen
     from urllib2 import HTTPError
 
-    def request(url, method, headers, data=None):
+    def request(url, method, headers, data=None, timeout=None):
         ''' Make an HTTP request in Python 2.x
 
         This method will abstract the underlying organization and invocation of
@@ -96,7 +96,7 @@ else:
             request.add_header('Content-Type', 'application/json')
             request.add_data(json.dumps(data))
 
-        response = urlopen(request).read()
+        response = urlopen(request, timeout=timeout).read()
 
         try:
             return json.loads(response)

--- a/pybutton/request.py
+++ b/pybutton/request.py
@@ -20,6 +20,7 @@ if sys.version_info[0] == 3:
     from urllib.request import Request
     from urllib.request import urlopen
     from urllib.error import HTTPError
+    from urllib.parse import urlunsplit
 
     def request(url, method, headers, data=None, timeout=None):
         ''' Make an HTTP request in Python 3.x
@@ -57,12 +58,20 @@ if sys.version_info[0] == 3:
         except ValueError:
             raise ButtonClientError('Invalid response: {0}'.format(response))
 
-    __all__ = [Request, urlopen, HTTPError, request]
+    def request_url(secure, hostname, port, path):
+        '''Combines url components into a url passable into the request function.'''
+        scheme = 'https' if secure else 'http'
+        netloc = '{0}:{1}'.format(hostname, port)
+
+        return urlunsplit((scheme, netloc, path, '', ''))
+
+    __all__ = [Request, urlopen, HTTPError, request, request_url]
 
 else:
     from urllib2 import Request
     from urllib2 import urlopen
     from urllib2 import HTTPError
+    from urlparse import urlunsplit
 
     def request(url, method, headers, data=None, timeout=None):
         ''' Make an HTTP request in Python 2.x
@@ -103,4 +112,11 @@ else:
         except ValueError:
             raise ButtonClientError('Invalid response: {0}'.format(response))
 
-    __all__ = [Request, urlopen, HTTPError, request]
+    def request_url(secure, hostname, port, path):
+        '''Combines url components into a url passable into the request function.'''
+        scheme = 'https' if secure else 'http'
+        netloc = '{0}:{1}'.format(hostname, port)
+
+        return urlunsplit((scheme, netloc, path, '', ''))
+
+    __all__ = [Request, urlopen, HTTPError, request, request_url]

--- a/pybutton/request.py
+++ b/pybutton/request.py
@@ -58,17 +58,6 @@ if sys.version_info[0] == 3:
         except ValueError:
             raise ButtonClientError('Invalid response: {0}'.format(response))
 
-    def request_url(secure, hostname, port, path):
-        ''' Combines url components into a url passable into the request
-        function. '''
-
-        scheme = 'https' if secure else 'http'
-        netloc = '{0}:{1}'.format(hostname, port)
-
-        return urlunsplit((scheme, netloc, path, '', ''))
-
-    __all__ = [Request, urlopen, HTTPError, request, request_url]
-
 else:
     from urllib2 import Request
     from urllib2 import urlopen
@@ -114,12 +103,13 @@ else:
         except ValueError:
             raise ButtonClientError('Invalid response: {0}'.format(response))
 
-    def request_url(secure, hostname, port, path):
-        ''' Combines url components into a url passable into the request
-        function. '''
-        scheme = 'https' if secure else 'http'
-        netloc = '{0}:{1}'.format(hostname, port)
 
-        return urlunsplit((scheme, netloc, path, '', ''))
+def request_url(secure, hostname, port, path):
+    ''' Combines url components into a url passable into the request
+    function. '''
+    scheme = 'https' if secure else 'http'
+    netloc = '{0}:{1}'.format(hostname, port)
 
-    __all__ = [Request, urlopen, HTTPError, request, request_url]
+    return urlunsplit((scheme, netloc, path, '', ''))
+
+__all__ = [Request, urlopen, HTTPError, request, request_url]

--- a/pybutton/resources/orders.py
+++ b/pybutton/resources/orders.py
@@ -17,8 +17,10 @@ class Orders(Resource):
             hostname: Defaults to api.usebutton.com.
             port: Defaults to 443 if config.secure, else defaults to 80.
             secure: Whether or not to use HTTPS. Defaults to True.
-            timeout: The time in seconds for network requests to abort. Defaults to None.
-              (N.B: Button's API is only exposed through HTTPS. This option is provided purely as a convenience for testing and development.)
+            timeout: The time in seconds for network requests to abort.
+              Defaults to None.
+              (N.B: Button's API is only exposed through HTTPS. This option is
+              provided purely as a convenience for testing and development.)
 
     Raises:
         pybutton.ButtonClientError

--- a/pybutton/resources/orders.py
+++ b/pybutton/resources/orders.py
@@ -13,6 +13,13 @@ class Orders(Resource):
         api_key (string): Your organization's API key.  Do find yours at
             https://app.usebutton.com/settings/organization.
 
+        config (dict): Configuration options for the client. Options include:
+            hostname: Defaults to api.usebutton.com.
+            port: Defaults to 443 if config.secure, else defaults to 80.
+            secure: Whether or not to use HTTPS. Defaults to True.
+            timeout: The time in seconds for network requests to abort. Defaults to None.
+              (N.B: Button's API is only exposed through HTTPS. This option is provided purely as a convenience for testing and development.)
+
     Raises:
         pybutton.ButtonClientError
 

--- a/pybutton/resources/resource.py
+++ b/pybutton/resources/resource.py
@@ -6,12 +6,12 @@ from __future__ import unicode_literals
 from base64 import b64encode
 from platform import python_version
 import json
-import urlparse
 
 from ..response import Response
 from ..error import ButtonClientError
 from ..version import VERSION
 from ..request import request
+from ..request import request_url
 from ..request import HTTPError
 
 USER_AGENT = 'pybutton/{0} python/{1}'.format(VERSION, python_version())
@@ -98,8 +98,7 @@ class Resource(object):
 
         '''
 
-        url = self._request_url(path)
-
+        url = request_url(self.config['secure'], self.config['hostname'], self.config['port'], path)
         api_key_bytes = '{0}:'.format(self.api_key).encode()
         authorization = b64encode(api_key_bytes).decode()
 
@@ -123,7 +122,3 @@ class Resource(object):
             error = json.loads(data).get('error', {})
             message = error.get('message', fallback)
             raise ButtonClientError(message)
-
-    def _request_url(self, path):
-        protocol = 'https' if self.config['secure'] else 'http'
-        return urlparse.urlunsplit((protocol, '{0}:{1}'.format(self.config['hostname'], self.config['port']), path, '', ''))

--- a/pybutton/resources/resource.py
+++ b/pybutton/resources/resource.py
@@ -31,8 +31,10 @@ class Resource(object):
             hostname: Defaults to api.usebutton.com.
             port: Defaults to 443 if config.secure, else defaults to 80.
             secure: Whether or not to use HTTPS. Defaults to True.
-            timeout: The time in seconds for network requests to abort. Defaults to None.
-              (N.B: Button's API is only exposed through HTTPS. This option is provided purely as a convenience for testing and development.)
+            timeout: The time in seconds for network requests to abort.
+              Defaults to None.
+              (N.B: Button's API is only exposed through HTTPS. This option is
+              provided purely as a convenience for testing and development.)
 
     Raises:
         pybutton.ButtonClientError
@@ -98,7 +100,12 @@ class Resource(object):
 
         '''
 
-        url = request_url(self.config['secure'], self.config['hostname'], self.config['port'], path)
+        url = request_url(
+            self.config['secure'],
+            self.config['hostname'],
+            self.config['port'],
+            path
+        )
         api_key_bytes = '{0}:'.format(self.api_key).encode()
         authorization = b64encode(api_key_bytes).decode()
 
@@ -108,7 +115,14 @@ class Resource(object):
         }
 
         try:
-            resp = request(url, method, headers, data, self.config['timeout']).get('object', {})
+            resp = request(
+                url,
+                method,
+                headers,
+                data,
+                self.config['timeout']
+            ).get('object', {})
+
             return Response(resp)
         except HTTPError as e:
             response = e.read()

--- a/pybutton/resources/resource.py
+++ b/pybutton/resources/resource.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from base64 import b64encode
 from platform import python_version
 import json
+import urlparse
 
 from ..response import Response
 from ..error import ButtonClientError
@@ -25,6 +26,13 @@ class Resource(object):
     Args:
         api_key (string): Your organization's API key.  Do find yours at
             https://app.usebutton.com/settings/organization.
+
+        config (dict): Configuration options for the client. Options include:
+            hostname: Defaults to api.usebutton.com.
+            port: Defaults to 443 if config.secure, else defaults to 80.
+            secure: Whether or not to use HTTPS. Defaults to True.
+            timeout: The time in seconds for network requests to abort. Defaults to None.
+              (N.B: Button's API is only exposed through HTTPS. This option is provided purely as a convenience for testing and development.)
 
     Raises:
         pybutton.ButtonClientError
@@ -117,5 +125,5 @@ class Resource(object):
             raise ButtonClientError(message)
 
     def _request_url(self, path):
-        protocol = 'https://' if self.config['secure'] else 'http://'
-        return '{0}{1}:{2}{3}'.format(protocol, self.config['hostname'], self.config['port'], path)
+        protocol = 'https' if self.config['secure'] else 'http'
+        return urlparse.urlunsplit((protocol, '{0}:{1}'.format(self.config['hostname'], self.config['port']), path, '', ''))

--- a/pybutton/version.py
+++ b/pybutton/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.2'
+VERSION = '1.1.0'

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -33,3 +33,42 @@ class ClientTestCase(TestCase):
     def test_orders(self):
         client = Client('sk-XXX')
         self.assertTrue(client.orders is not None)
+
+    def test_config(self):
+        client = Client('sk-XXX')
+
+        # Defaults
+        config = client._config_with_defaults({})
+
+        self.assertEqual(config, {
+            'hostname': 'api.usebutton.com',
+            'port': 443,
+            'secure': True,
+            'timeout': None
+        })
+
+        # Port and timeout overrides
+        config = client._config_with_defaults({
+            'port': 88,
+            'timeout': 5
+        })
+
+        self.assertEqual(config, {
+            'hostname': 'api.usebutton.com',
+            'port': 88,
+            'secure': True,
+            'timeout': 5
+        })
+
+        # Hostname and secure overrides
+        config = client._config_with_defaults({
+            'hostname': 'localhost',
+            'secure': False
+        })
+
+        self.assertEqual(config, {
+            'hostname': 'localhost',
+            'port': 80,
+            'secure': False,
+            'timeout': None
+        })

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 from unittest import TestCase
 
 from pybutton.client import Client
-from pybutton.client import _config_with_defaults
+from pybutton.client import config_with_defaults
 from pybutton import ButtonClientError
 
 
@@ -37,7 +37,7 @@ class ClientTestCase(TestCase):
 
     def test_config(self):
         # Defaults
-        config = _config_with_defaults({})
+        config = config_with_defaults({})
 
         self.assertEqual(config, {
             'hostname': 'api.usebutton.com',
@@ -47,7 +47,7 @@ class ClientTestCase(TestCase):
         })
 
         # Port and timeout overrides
-        config = _config_with_defaults({
+        config = config_with_defaults({
             'port': 88,
             'timeout': 5
         })
@@ -60,7 +60,7 @@ class ClientTestCase(TestCase):
         })
 
         # Hostname and secure overrides
-        config = _config_with_defaults({
+        config = config_with_defaults({
             'hostname': 'localhost',
             'secure': False
         })

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -43,31 +43,31 @@ class ClientTestCase(TestCase):
             'hostname': 'api.usebutton.com',
             'port': 443,
             'secure': True,
-            'timeout': None
+            'timeout': None,
         })
 
         # Port and timeout overrides
         config = config_with_defaults({
             'port': 88,
-            'timeout': 5
+            'timeout': 5,
         })
 
         self.assertEqual(config, {
             'hostname': 'api.usebutton.com',
             'port': 88,
             'secure': True,
-            'timeout': 5
+            'timeout': 5,
         })
 
         # Hostname and secure overrides
         config = config_with_defaults({
             'hostname': 'localhost',
-            'secure': False
+            'secure': False,
         })
 
         self.assertEqual(config, {
             'hostname': 'localhost',
             'port': 80,
             'secure': False,
-            'timeout': None
+            'timeout': None,
         })

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from unittest import TestCase
 
 from pybutton.client import Client
+from pybutton.client import _config_with_defaults
 from pybutton import ButtonClientError
 
 
@@ -35,10 +36,8 @@ class ClientTestCase(TestCase):
         self.assertTrue(client.orders is not None)
 
     def test_config(self):
-        client = Client('sk-XXX')
-
         # Defaults
-        config = client._config_with_defaults({})
+        config = _config_with_defaults({})
 
         self.assertEqual(config, {
             'hostname': 'api.usebutton.com',
@@ -48,7 +47,7 @@ class ClientTestCase(TestCase):
         })
 
         # Port and timeout overrides
-        config = client._config_with_defaults({
+        config = _config_with_defaults({
             'port': 88,
             'timeout': 5
         })
@@ -61,7 +60,7 @@ class ClientTestCase(TestCase):
         })
 
         # Hostname and secure overrides
-        config = client._config_with_defaults({
+        config = _config_with_defaults({
             'hostname': 'localhost',
             'secure': False
         })

--- a/test/request_test.py
+++ b/test/request_test.py
@@ -200,8 +200,17 @@ class RequestTestCasePy3(TestCase):
                 pass
 
     def test_request_url(self):
-        path = request_url(True, 'api.usebutton.com', 443, '/v1/api/btnorder-XXX')
-        self.assertEqual(path, 'https://api.usebutton.com:443/v1/api/btnorder-XXX')
+        path = request_url(
+            True,
+            'api.usebutton.com',
+            443,
+            '/v1/api/btnorder-XXX'
+        )
+
+        self.assertEqual(
+            path,
+            'https://api.usebutton.com:443/v1/api/btnorder-XXX'
+        )
 
         path = request_url(False, 'localhost', 80, '/v1/api/btnorder-XXX')
         self.assertEqual(path, 'http://localhost:80/v1/api/btnorder-XXX')

--- a/test/request_test.py
+++ b/test/request_test.py
@@ -10,6 +10,7 @@ from mock import Mock
 from mock import patch
 
 from pybutton.request import request
+from pybutton.request import request_url
 from pybutton import ButtonClientError
 
 
@@ -197,3 +198,10 @@ class RequestTestCasePy3(TestCase):
                 self.assertTrue(False)
             except ButtonClientError:
                 pass
+
+    def test_request_url(self):
+        path = request_url(True, 'api.usebutton.com', 443, '/v1/api/btnorder-XXX')
+        self.assertEqual(path, 'https://api.usebutton.com:443/v1/api/btnorder-XXX')
+
+        path = request_url(False, 'localhost', 80, '/v1/api/btnorder-XXX')
+        self.assertEqual(path, 'http://localhost:80/v1/api/btnorder-XXX')

--- a/test/resources/orders_test.py
+++ b/test/resources/orders_test.py
@@ -9,16 +9,22 @@ from mock import patch
 
 from pybutton.resources import Orders
 
+config = {
+    'hostname': 'api.usebutton.com',
+    'secure': True,
+    'port': 443,
+    'timeout': None
+}
 
 class OrdersTestCase(TestCase):
 
         def test_path(self):
-            order = Orders('sk-XXX')
+            order = Orders('sk-XXX', config)
             self.assertEqual(order._path(), '/v1/order')
             self.assertEqual(order._path('btnorder-1'), '/v1/order/btnorder-1')
 
         def test_get(self):
-            order = Orders('sk-XXX')
+            order = Orders('sk-XXX', config)
             order_response = {'a': 1}
 
             api_get = Mock()
@@ -31,7 +37,7 @@ class OrdersTestCase(TestCase):
             api_get.assert_called_with('/v1/order/btnorder-XXX')
 
         def test_create(self):
-            order = Orders('sk-XXX')
+            order = Orders('sk-XXX', config)
             order_payload = {'b': 2}
             order_response = {'a': 1}
 
@@ -45,7 +51,7 @@ class OrdersTestCase(TestCase):
             api_post.assert_called_with('/v1/order', order_payload)
 
         def test_update(self):
-            order = Orders('sk-XXX')
+            order = Orders('sk-XXX', config)
             order_payload = {'b': 2}
             order_response = {'a': 1}
 
@@ -62,7 +68,7 @@ class OrdersTestCase(TestCase):
             )
 
         def test_delete(self):
-            order = Orders('sk-XXX')
+            order = Orders('sk-XXX', config)
             order_response = {'a': 1}
 
             api_delete = Mock()

--- a/test/resources/orders_test.py
+++ b/test/resources/orders_test.py
@@ -16,6 +16,7 @@ config = {
     'timeout': None
 }
 
+
 class OrdersTestCase(TestCase):
 
         def test_path(self):

--- a/test/resources/resource_test.py
+++ b/test/resources/resource_test.py
@@ -15,7 +15,7 @@ config = {
     'hostname': 'api.usebutton.com',
     'secure': True,
     'port': 443,
-    'timeout': None
+    'timeout': None,
 }
 
 

--- a/test/resources/resource_test.py
+++ b/test/resources/resource_test.py
@@ -18,6 +18,7 @@ config = {
     'timeout': None
 }
 
+
 class ResourceTestCase(TestCase):
 
     @patch('pybutton.resources.resource.request')

--- a/test/resources/resource_test.py
+++ b/test/resources/resource_test.py
@@ -166,16 +166,3 @@ class ResourceTestCase(TestCase):
         self.assertTrue(len(args[2]['User-Agent']) != 0)
         self.assertEqual(args[2]['Authorization'], 'Basic c2stWFhYOg==')
         self.assertEqual(args[3], None)
-
-    def test_request_url(self):
-        resource = Resource('sk-XXX', config)
-        path = resource._request_url('/v1/api/btnorder-XXX')
-        self.assertEqual(path, 'https://api.usebutton.com:443/v1/api/btnorder-XXX')
-
-        resource = Resource('sk-XXX', {
-            'hostname': 'localhost',
-            'port': 80,
-            'secure': False
-        })
-        path = resource._request_url('/v1/api/btnorder-XXX')
-        self.assertEqual(path, 'http://localhost:80/v1/api/btnorder-XXX')

--- a/test/resources/resource_test.py
+++ b/test/resources/resource_test.py
@@ -11,6 +11,12 @@ from pybutton.request import HTTPError
 from pybutton.resources.resource import Resource
 from pybutton.error import ButtonClientError
 
+config = {
+    'hostname': 'api.usebutton.com',
+    'secure': True,
+    'port': 443,
+    'timeout': None
+}
 
 class ResourceTestCase(TestCase):
 
@@ -18,12 +24,12 @@ class ResourceTestCase(TestCase):
     def test_api_request(self, request):
         resource_response = {'a': 1}
         request.return_value = {'object': resource_response}
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
         response = resource._api_request('/v1/api', 'GET')
 
         args = request.call_args[0]
         self.assertEqual(response.to_dict(), resource_response)
-        self.assertEqual(args[0], 'https://api.usebutton.com/v1/api')
+        self.assertEqual(args[0], 'https://api.usebutton.com:443/v1/api')
         self.assertEqual(args[1], 'GET')
         self.assertTrue(len(args[2]['User-Agent']) != 0)
         self.assertEqual(args[2]['Authorization'], 'Basic c2stWFhYOg==')
@@ -33,12 +39,12 @@ class ResourceTestCase(TestCase):
     def test_api_request_with_other_methods(self, request):
         resource_response = {'a': 1}
         request.return_value = {'object': resource_response}
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
         response = resource._api_request('/v1/api', 'POST')
 
         args = request.call_args[0]
         self.assertEqual(response.to_dict(), resource_response)
-        self.assertEqual(args[0], 'https://api.usebutton.com/v1/api')
+        self.assertEqual(args[0], 'https://api.usebutton.com:443/v1/api')
         self.assertEqual(args[1], 'POST')
         self.assertTrue(len(args[2]['User-Agent']) != 0)
         self.assertEqual(args[2]['Authorization'], 'Basic c2stWFhYOg==')
@@ -48,12 +54,12 @@ class ResourceTestCase(TestCase):
     def test_api_request_with_other_paths(self, request):
         resource_response = {'a': 1}
         request.return_value = {'object': resource_response}
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
         response = resource._api_request('/v2/api', 'GET')
 
         args = request.call_args[0]
         self.assertEqual(response.to_dict(), resource_response)
-        self.assertEqual(args[0], 'https://api.usebutton.com/v2/api')
+        self.assertEqual(args[0], 'https://api.usebutton.com:443/v2/api')
         self.assertEqual(args[1], 'GET')
         self.assertTrue(len(args[2]['User-Agent']) != 0)
         self.assertEqual(args[2]['Authorization'], 'Basic c2stWFhYOg==')
@@ -64,12 +70,12 @@ class ResourceTestCase(TestCase):
         data = {'c': 3}
         resource_response = {'a': 1}
         request.return_value = {'object': resource_response}
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
         response = resource._api_request('/v2/api', 'GET', data)
 
         args = request.call_args[0]
         self.assertEqual(response.to_dict(), resource_response)
-        self.assertEqual(args[0], 'https://api.usebutton.com/v2/api')
+        self.assertEqual(args[0], 'https://api.usebutton.com:443/v2/api')
         self.assertEqual(args[1], 'GET')
         self.assertTrue(len(args[2]['User-Agent']) != 0)
         self.assertEqual(args[2]['Authorization'], 'Basic c2stWFhYOg==')
@@ -86,7 +92,7 @@ class ResourceTestCase(TestCase):
             raise HTTPError('url', 404, 'bloop', {}, fp)
 
         request.side_effect = side_effect
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
 
         try:
             resource._api_request('/v2/api', 'GET', data)
@@ -107,7 +113,7 @@ class ResourceTestCase(TestCase):
             raise HTTPError('url', 404, 'bloop', {}, fp)
 
         request.side_effect = side_effect
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
 
         try:
             resource._api_request('/v2/api', 'GET', data)
@@ -119,12 +125,12 @@ class ResourceTestCase(TestCase):
     def test_api_get(self, request):
         resource_response = {'a': 1}
         request.return_value = {'object': resource_response}
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
         response = resource.api_get('/v1/api')
 
         args = request.call_args[0]
         self.assertEqual(response.to_dict(), resource_response)
-        self.assertEqual(args[0], 'https://api.usebutton.com/v1/api')
+        self.assertEqual(args[0], 'https://api.usebutton.com:443/v1/api')
         self.assertEqual(args[1], 'GET')
         self.assertTrue(len(args[2]['User-Agent']) != 0)
         self.assertEqual(args[2]['Authorization'], 'Basic c2stWFhYOg==')
@@ -135,12 +141,12 @@ class ResourceTestCase(TestCase):
         request_payload = {'c': 3}
         resource_response = {'a': 1}
         request.return_value = {'object': resource_response}
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
         response = resource.api_post('/v1/api', request_payload)
 
         args = request.call_args[0]
         self.assertEqual(response.to_dict(), resource_response)
-        self.assertEqual(args[0], 'https://api.usebutton.com/v1/api')
+        self.assertEqual(args[0], 'https://api.usebutton.com:443/v1/api')
         self.assertEqual(args[1], 'POST')
         self.assertTrue(len(args[2]['User-Agent']) != 0)
         self.assertEqual(args[2]['Authorization'], 'Basic c2stWFhYOg==')
@@ -150,13 +156,26 @@ class ResourceTestCase(TestCase):
     def test_api_delete(self, request):
         resource_response = {'a': 1}
         request.return_value = {'object': resource_response}
-        resource = Resource('sk-XXX')
+        resource = Resource('sk-XXX', config)
         response = resource.api_delete('/v1/api')
 
         args = request.call_args[0]
         self.assertEqual(response.to_dict(), resource_response)
-        self.assertEqual(args[0], 'https://api.usebutton.com/v1/api')
+        self.assertEqual(args[0], 'https://api.usebutton.com:443/v1/api')
         self.assertEqual(args[1], 'DELETE')
         self.assertTrue(len(args[2]['User-Agent']) != 0)
         self.assertEqual(args[2]['Authorization'], 'Basic c2stWFhYOg==')
         self.assertEqual(args[3], None)
+
+    def test_request_url(self):
+        resource = Resource('sk-XXX', config)
+        path = resource._request_url('/v1/api/btnorder-XXX')
+        self.assertEqual(path, 'https://api.usebutton.com:443/v1/api/btnorder-XXX')
+
+        resource = Resource('sk-XXX', {
+            'hostname': 'localhost',
+            'port': 80,
+            'secure': False
+        })
+        path = resource._request_url('/v1/api/btnorder-XXX')
+        self.assertEqual(path, 'http://localhost:80/v1/api/btnorder-XXX')


### PR DESCRIPTION
### Description

Add hostname, secure, port, timeout options
### Test Plan
- Updated unit tests to include configs
- Tested against api.usebutton, staging, SimpleHTTPServer
