### PR TITLE
Add tox + python3.6 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - "pip install flake8==3.3.0"
 script: python setup.py test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 Current Version
+  - Add tox
+  - Add support for python3.6
   - Add flake8 to test suite
   - Move /test directory inside package
   - Migrate relative imports to package absolute

--- a/README.rst
+++ b/README.rst
@@ -334,6 +334,9 @@ Contributing
 -  Installing locally: ``python setup.py install``
 -  Running tests: ``python setup.py test`` (you'll need to `pip install flake8==3.3.0`)
 -  Running lint directly: ``flake8 pybutton``
+-  Running tests on all versions: ``tox``
+    - Pre-req: `pip install tox`
+    - Pre-req (if using pyenv): something like `pyenv local 2.7.10 2.6.9 3.1.5 3.3.6 3.4.6 3.5.3 3.6.0`
 
 .. |Build Status| image:: https://travis-ci.org/button/button-client-python.svg?branch=master
    :target: https://travis-ci.org/button/button-client-python

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ touch <https://www.usebutton.com/contact>`__.
 Supported runtimes
 ^^^^^^^^^^^^^^^^^^
 
--  cPython ``2.6``, ``2.7``, ``3.2``, ``3.3``, ``3.4``, ``3.5``
+-  cPython ``2.6``, ``2.7``, ``3.2``, ``3.3``, ``3.4``, ``3.5``, ``3.6``
 
 Dependencies
 ^^^^^^^^^^^^

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py26, py27, py33, py34, py35, py36
+skip_missing_interpreters = True
+
+[testenv]
+deps =
+  nose
+  mock
+commands =
+    python setup.py clean --all
+    python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ skip_missing_interpreters = True
 
 [testenv]
 deps =
-  nose
-  mock
+    nose
+    mock
 commands =
     python setup.py clean --all
     python setup.py test


### PR DESCRIPTION
### Description

* [tox](https://tox.readthedocs.io) is a tool for running a suite of tests in many virtualenvs.  Handy for testing locally against many pythons.  Here, we add `tox` as an optional test runner
* Add support for testing `python3.6`  on CI.