### PR TITLE
Add HTTPResponseError to top-level import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Current Version
   -
 
+2.6.1 June 5, 2018
+  - Added `HTTPResponseError` to top-level import
+  - Remove `__all__` imports: they never worked
+
 2.6.0 May 17, 2018
   - Added `HTTPResponseError`
 

--- a/pybutton/__init__.py
+++ b/pybutton/__init__.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from pybutton.client import Client
-from pybutton.error import ButtonClientError
-from pybutton.error import HTTPResponseError
-from pybutton.version import VERSION
+from pybutton.client import Client # noqa: 401
+from pybutton.error import ButtonClientError # noqa: 401
+from pybutton.error import HTTPResponseError # noqa: 401
+from pybutton.version import VERSION # noqa: 401

--- a/pybutton/__init__.py
+++ b/pybutton/__init__.py
@@ -5,6 +5,5 @@ from __future__ import unicode_literals
 
 from pybutton.client import Client
 from pybutton.error import ButtonClientError
+from pybutton.error import HTTPResponseError
 from pybutton.version import VERSION
-
-__all__ = [Client, ButtonClientError, VERSION]

--- a/pybutton/request.py
+++ b/pybutton/request.py
@@ -151,13 +151,3 @@ def query_dict(url):
     if (url_components):
         query_string = url_components.query
         return parse_qs(query_string)
-
-
-__all__ = [
-    Request,
-    urlopen,
-    HTTPError,
-    request,
-    request_url,
-    query_dict,
-]

--- a/pybutton/request.py
+++ b/pybutton/request.py
@@ -64,7 +64,7 @@ if sys.version_info[0] == 3:
 else:
     from urllib2 import Request
     from urllib2 import urlopen
-    from urllib2 import HTTPError
+    from urllib2 import HTTPError # noqa: 401
     from urllib import urlencode
     from urlparse import urlunsplit
     from urlparse import urlparse

--- a/pybutton/resources/__init__.py
+++ b/pybutton/resources/__init__.py
@@ -8,11 +8,3 @@ from pybutton.resources.customers import Customers
 from pybutton.resources.links import Links
 from pybutton.resources.merchants import Merchants
 from pybutton.resources.orders import Orders
-
-__all__ = [
-    Accounts,
-    Customers,
-    Links,
-    Merchants,
-    Orders
-]

--- a/pybutton/resources/__init__.py
+++ b/pybutton/resources/__init__.py
@@ -3,8 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from pybutton.resources.accounts import Accounts
-from pybutton.resources.customers import Customers
-from pybutton.resources.links import Links
-from pybutton.resources.merchants import Merchants
-from pybutton.resources.orders import Orders
+from pybutton.resources.accounts import Accounts # noqa: 401
+from pybutton.resources.customers import Customers # noqa: 401
+from pybutton.resources.links import Links # noqa: 401
+from pybutton.resources.merchants import Merchants # noqa: 401
+from pybutton.resources.orders import Orders # noqa: 401

--- a/pybutton/version.py
+++ b/pybutton/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.6.0'
+VERSION = '2.6.1'


### PR DESCRIPTION
### Description

This PR ships two changes and cuts a new release (`v2.6.1`)

1) Adds `HTTPResponseError` to the top-level module, so `from pybutton import HTTPResponseError` works. 
2) Removes `__all__` declarations in all modules.  These never worked--python expects a non-unicode string identifying the value to export.  While this in some worlds could justify a major version bump, I'm just doing a patch because no one could be depending on this functionality yet. 