### PR TITLE
Add time_field to accounts#transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Current Version
   -
 
+2.7.0 June 21, 2018
+  - Added optional `time_field` argument to `client.accounts.transactions`
+
 2.6.1 June 5, 2018
   - Added `HTTPResponseError` to top-level import
   - Remove `__all__` imports: they never worked

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,7 @@ pass the following optional arguments:
 * ``cursor`` (string): An API cursor to fetch a specific set of results.
 * ``start`` (ISO-8601 datetime string): Fetch transactions after this time.
 * ``end`` (ISO-8601 datetime string): Fetch transactions before this time.
+* ``time_field`` (string): Which time field ``start`` and ``end`` filter on.
 
 .. code:: python
 

--- a/pybutton/resources/accounts.py
+++ b/pybutton/resources/accounts.py
@@ -26,7 +26,8 @@ class Accounts(Resource):
 
         return self.api_get('/v1/affiliation/accounts')
 
-    def transactions(self, account_id, cursor=None, start=None, end=None, time_field=None):
+    def transactions(self, account_id, cursor=None, start=None, end=None,
+                     time_field=None):
         '''Get a list of transactions.
         To paginate transactions, pass the result of response.next_cursor() as
         the cursor argument.

--- a/pybutton/resources/accounts.py
+++ b/pybutton/resources/accounts.py
@@ -26,7 +26,7 @@ class Accounts(Resource):
 
         return self.api_get('/v1/affiliation/accounts')
 
-    def transactions(self, account_id, cursor=None, start=None, end=None):
+    def transactions(self, account_id, cursor=None, start=None, end=None, time_field=None):
         '''Get a list of transactions.
         To paginate transactions, pass the result of response.next_cursor() as
         the cursor argument.
@@ -40,6 +40,8 @@ class Accounts(Resource):
                 created at or after this time.
             end (ISO-8601 datetime str) optional: Filter out transactions
                 created before this time.
+            time_field (str) optional: Which time field ``start`` and ``end``
+                filter on
 
         Raises:
             pybutton.ButtonClientError
@@ -57,6 +59,8 @@ class Accounts(Resource):
             query['start'] = start
         if end:
             query['end'] = end
+        if time_field:
+            query['time_field'] = time_field
 
         path = '/v1/affiliation/accounts/{0}/transactions'.format(
             account_id

--- a/pybutton/test/resources/accounts_test.py
+++ b/pybutton/test/resources/accounts_test.py
@@ -58,3 +58,14 @@ class AccountsTestCase(TestCase):
                 self.assertEqual(query['cursor'], 'abc')
                 self.assertEqual(query['start'], '2016-09-15T00:00:00.000Z')
                 self.assertEqual(query['end'], '2016-09-30T00:00:00.000Z')
+
+                response = account.transactions(
+                    'acc-123',
+                    cursor='abc',
+                    start='2016-09-15T00:00:00.000Z',
+                    end='2016-09-30T00:00:00.000Z',
+                    time_field='created_date'
+                )
+                self.assertEqual(response, account_response)
+                query = api_get.call_args[1]['query']
+                self.assertEqual(query['time_field'], 'created_date')

--- a/pybutton/version.py
+++ b/pybutton/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.6.1'
+VERSION = '2.7.0'


### PR DESCRIPTION
### Description

This PR adds `time_field` as a request parameter to calls for transactions, per our [public API docs](https://developer.usebutton.com/api#transactions).

It also cuts a new release to ship this feature. 