### PR TITLE
Update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,8 @@ All
     print(response)
     # <class pybutton.Response [2 elements]>
 
-Transactions
-''''''''''''
+Transactions (per-account)
+''''''''''''''''''''''''''
 
 Along with the required account ID, you may also
 pass the following optional arguments:


### PR DESCRIPTION
I believe having two headings with the same name in the same rst document caused compilation to fail, and thus publishing the package. 

Accordingly, this adds some nuance to one of the headings to distinguish it from the new top-level resource. 

Here's the lint failure get locally:

```bash
$ rst-lint README.rst
ERROR README.rst:99 Duplicate target name, cannot be used as a unique reference: "transactions".
```